### PR TITLE
Improve persistent game sync panel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,21 +4,24 @@ import Header from './components/Header';
 import Marketplace from './components/Marketplace';
 import Dashboard from './components/Dashboard';
 import Analytics from './components/Analytics';
+import { GameIntegrationProvider } from './context/GameIntegrationContext';
 
 function App() {
   const [user, setUser] = useState<any>(null);
 
   return (
-    <Router>
-      <div className="min-h-screen bg-gray-900">
-        <Header user={user} setUser={setUser} />
-        <Routes>
-          <Route path="/" element={<Marketplace user={user} setUser={setUser} />} />
-          <Route path="/dashboard" element={<Dashboard user={user} />} />
-          <Route path="/analytics" element={<Analytics />} />
-        </Routes>
-      </div>
-    </Router>
+    <GameIntegrationProvider>
+      <Router>
+        <div className="min-h-screen bg-gray-900">
+          <Header user={user} setUser={setUser} />
+          <Routes>
+            <Route path="/" element={<Marketplace user={user} setUser={setUser} />} />
+            <Route path="/dashboard" element={<Dashboard user={user} />} />
+            <Route path="/analytics" element={<Analytics />} />
+          </Routes>
+        </div>
+      </Router>
+    </GameIntegrationProvider>
   );
 }
 

--- a/src/context/GameIntegrationContext.tsx
+++ b/src/context/GameIntegrationContext.tsx
@@ -1,0 +1,102 @@
+import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import { signMessage } from '../utils/web3';
+
+export type GameStatus = 'disconnected' | 'connecting' | 'connected' | 'syncing';
+
+interface GameIntegrationState {
+  isGameConnected: boolean;
+  gameStatus: GameStatus;
+  syncCode: string | null;
+  inGameId: string | null;
+  wallet: string | null;
+}
+
+interface GameIntegrationContextType extends GameIntegrationState {
+  connectGame: () => Promise<void>;
+  disconnectGame: () => void;
+  requestPairing: (wallet: string) => Promise<void>;
+  syncAssets: (wallet: string) => Promise<void>;
+  setGameStatus: (s: GameStatus) => void;
+}
+
+const defaultState: GameIntegrationState = {
+  isGameConnected: false,
+  gameStatus: 'disconnected',
+  syncCode: null,
+  inGameId: null,
+  wallet: null
+};
+
+const GameIntegrationContext = createContext<GameIntegrationContextType | undefined>(undefined);
+
+export const GameIntegrationProvider = ({ children }: { children: ReactNode }) => {
+  const [state, setState] = useState<GameIntegrationState>(() => {
+    const stored = localStorage.getItem('gameIntegration');
+    return stored ? { ...defaultState, ...JSON.parse(stored) } : defaultState;
+  });
+
+  useEffect(() => {
+    localStorage.setItem('gameIntegration', JSON.stringify(state));
+  }, [state]);
+
+  const connectGame = async () => {
+    setState(prev => ({ ...prev, gameStatus: 'connecting' }));
+    await new Promise(res => setTimeout(res, 2000));
+    setState(prev => ({ ...prev, isGameConnected: true, gameStatus: 'connected' }));
+  };
+
+  const disconnectGame = () => {
+    setState({ ...defaultState, gameStatus: 'disconnected' });
+  };
+
+  const requestPairing = async (wallet: string) => {
+    const code = Math.random().toString(36).substr(2, 6).toUpperCase();
+    const message = `/sync ${code}`;
+    const sig = await signMessage(wallet, message);
+    if (!sig) return;
+    setState(prev => ({ ...prev, syncCode: code, wallet, gameStatus: 'connecting' }));
+    setTimeout(async () => {
+      try {
+        const res = await fetch('/api/verify-sync');
+        if (res.ok) {
+          setState(prev => ({
+            ...prev,
+            syncCode: null,
+            gameStatus: 'connected',
+            inGameId: `RaceVault_${wallet.slice(-8).toUpperCase()}`
+          }));
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    }, 3000);
+  };
+
+  const syncAssets = async (wallet: string) => {
+    setState(prev => ({ ...prev, gameStatus: 'syncing' }));
+    try {
+      await fetch('/api/sync-assets');
+      setState(prev => ({ ...prev, gameStatus: 'connected', wallet }));
+    } catch (err) {
+      console.error(err);
+      setState(prev => ({ ...prev, gameStatus: 'connected' }));
+    }
+  };
+
+  const setGameStatus = (s: GameStatus) => {
+    setState(prev => ({ ...prev, gameStatus: s }));
+  };
+
+  return (
+    <GameIntegrationContext.Provider value={{ ...state, connectGame, disconnectGame, requestPairing, syncAssets, setGameStatus }}>
+      {children}
+    </GameIntegrationContext.Provider>
+  );
+};
+
+export const useGameIntegration = () => {
+  const ctx = useContext(GameIntegrationContext);
+  if (!ctx) throw new Error('useGameIntegration must be used within GameIntegrationProvider');
+  return ctx;
+};
+


### PR DESCRIPTION
## Summary
- wrap app in `GameIntegrationProvider`
- store game integration details in new React context
- update panel to use context data and show wallet info
- allow syncing assets and keep connection when panel unmounts

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6881f458d21c8331a2e93c6f63ea3e21